### PR TITLE
export-ignores for releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/CODEOWNERS export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yaml export-ignore
+/README.md export-ignore
+/Makefile export-ignore
+/test export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,9 +2,6 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yaml export-ignore
-/README.md export-ignore
-/migrations/README.md export-ignore
-/schemas/README.md export-ignore
-/views/README.md export-ignore
+README.md export-ignore
 /Makefile export-ignore
 /test export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,8 @@
 /.gitignore export-ignore
 /.travis.yaml export-ignore
 /README.md export-ignore
+/migrations/README.md export-ignore
+/schemas/README.md export-ignore
+/views/README.md export-ignore
 /Makefile export-ignore
 /test export-ignore

--- a/test/validate.py
+++ b/test/validate.py
@@ -12,7 +12,7 @@ from jsonschema.exceptions import ValidationError
 def validate_json_schemas():
     """Validate the syntax of all the JSON schemas."""
     print('Validating JSON schemas..')
-    names = {}
+    names = {}  # type: dict
     for path in glob.iglob('schemas/**/*.json', recursive=True):
         name = os.path.basename(path)
         # Make sure collection is lower snake case
@@ -63,7 +63,7 @@ def validate_aql_syntax():
     """Validate the syntax of all the queries."""
     # TODO check AQL syntax. Unsure how to do this without connecting to a running arango server :/
     print('Validating AQL queries..')
-    names = {}
+    names = {}  # type: dict
     for path in glob.iglob('views/**/*.aql', recursive=True):
         name = os.path.basename(path)
         if names.get(name):


### PR DESCRIPTION
I'd like to go the releases route for pulling specs in the API. One of the advantages is we can disclude a bunch of files in the release tarball using `.gitattributes` to make it even smaller to fetch.