### PR TITLE
(Discussion) graph definitions instead of edge schemas

### DIFF
--- a/schemas/graphs/chemical_reactions.json
+++ b/schemas/graphs/chemical_reactions.json
@@ -1,0 +1,28 @@
+[
+  {
+    "edge": "is_similar_to",
+    "from": "reactions",
+    "to": "reactions",
+    "edgeSchema": {
+      "type": "object",
+      "required": ["jaccard_similarity"],
+      "properties": {
+        "jaccard_similarity": {
+          "type": "number",
+          "min": 0,
+          "max": 1
+        }
+      }
+    }
+  },
+  {
+    "edge": "contains",
+    "from": "gene_reaction_complexes",
+    "to": "features"
+  },
+  {
+    "edge": "produces",
+    "from": "gene_reaction_complexes",
+    "to": "chemical_reactions"
+  }
+]

--- a/schemas/graphs/example_graph.json
+++ b/schemas/graphs/example_graph.json
@@ -1,0 +1,7 @@
+[
+  {
+    "edge": "example_edges",
+    "from": "example_vertices",
+    "to": "example_vertices"
+  }
+]

--- a/schemas/graphs/genome_info.json
+++ b/schemas/graphs/genome_info.json
@@ -1,0 +1,17 @@
+[
+  {
+    "edge": "contains",
+    "from": "genomes",
+    "to": "features"
+  },
+  {
+    "edge": "has_detail",
+    "from": "ws_object_versions",
+    "to": "genomes"
+  },
+  {
+    "edge": "published_in",
+    "from": "genomes",
+    "to": "publications"
+  }
+]

--- a/schemas/graphs/taxonomy.json
+++ b/schemas/graphs/taxonomy.json
@@ -1,0 +1,7 @@
+[
+  {
+    "edge": "child_of",
+    "from": "taxa",
+    "to": "taxa"
+  }
+]

--- a/schemas/graphs/workspace_objects.json
+++ b/schemas/graphs/workspace_objects.json
@@ -60,17 +60,22 @@
     "to": "types"
   },
   {
-    "edge": "was_created_with_module",
+    "edge": "created_with_module",
     "from": "ws_object_versions",
     "to": "sdk_module_versions"
   },
   {
-    "edge": "was_created_with_method",
+    "edge": "created_with_method",
     "from": "ws_object_versions",
-    "to": "sdk_module_method_versions"
+    "to": "sdk_module_method_versions",
+    "edgeSchema": {
+      "type": "object",
+      "required": ["method_params"],
+      "properties": {"method_params": {"type": "object"}}
+    }
   },
   {
-    "edge": "was_created_from_object",
+    "edge": "created_from_object",
     "from": "ws_object_versions",
     "to": "ws_object_versions"
   },

--- a/schemas/graphs/workspace_objects.json
+++ b/schemas/graphs/workspace_objects.json
@@ -1,0 +1,112 @@
+[
+  {
+    "edge": "is_latest_version_of",
+    "from": "sdk_module_versions",
+    "to": "sdk_modules"
+  },
+  {
+    "edge": "is_version_of",
+    "from": "sdk_module_versions",
+    "to": "sdk_modules"
+  },
+  {
+    "edge": "is_version_of",
+    "from": "type_versions",
+    "to": "types"
+  },
+  {
+    "edge": "is_latest_version_of",
+    "from": "type_versions",
+    "to": "types"
+  },
+  {
+    "edge": "is_latest_version_of",
+    "from": "sdk_module_method_versions",
+    "to": "sdk_module_methods"
+  },
+  {
+    "edge": "is_version_of",
+    "from": "sdk_module_method_versions",
+    "to": "sdk_module_methods"
+  },
+  {
+    "edge": "is_latest_version_of",
+    "from": "ws_object_versions",
+    "to": "ws_objects"
+  },
+  {
+    "edge": "is_version_of",
+    "from": "ws_object_versions",
+    "to": "ws_objects"
+  },
+  {
+    "edge": "contains_method",
+    "from": "sdk_module",
+    "to": "sdk_method"
+  },
+  {
+    "edge": "contains_method_version",
+    "from": "sdk_module_version",
+    "to": "sdk_module_method_version"
+  },
+  {
+    "edge": "contains_object",
+    "from": "workspaces",
+    "to": "ws_objects"
+  },
+  {
+    "edge": "contains_type",
+    "from": "type_modules",
+    "to": "types"
+  },
+  {
+    "edge": "was_created_with_module",
+    "from": "ws_object_versions",
+    "to": "sdk_module_versions"
+  },
+  {
+    "edge": "was_created_with_method",
+    "from": "ws_object_versions",
+    "to": "sdk_module_method_versions"
+  },
+  {
+    "edge": "was_created_from_object",
+    "from": "ws_object_versions",
+    "to": "ws_object_versions"
+  },
+  {
+    "edge": "refers_to",
+    "from": "ws_object_versions",
+    "to": "ws_object_versions"
+  },
+  {
+    "edge": "was_copied_from",
+    "from": "ws_object_versions",
+    "to": "ws_object_versions"
+  },
+  {
+    "edge": "is_owner_of",
+    "from": "users",
+    "to": "workspaces"
+  },
+  {
+    "edge": "can_read",
+    "from": "users",
+    "to": "workspaces"
+  },
+  {
+    "edge": "can_write",
+    "from": "users",
+    "to": "workspaces"
+  },
+  {
+    "edge": "has_hash",
+    "from": "ws_object_versions",
+    "to": "object_hashes"
+  },
+  {
+    "edge": "has_input_type",
+    "from": "types",
+    "to": "sdk_method_versions"
+  }
+]


### PR DESCRIPTION
This defines edges inside of whole graphs, connected to "from" and "to collections, rather than in isolation in a single schema.

The API would initialize the edges and graphs, with edge keys being taken care of automatically on creation/update.

If we decide this is a good idea, then todos are:
- [ ] update validator in this repo to validate graphs
- [ ] remove old edge schemas
- [ ] update API to initialize the database from graphs
- [ ] update the API to bulk import with validation against graph schemas