### PR TITLE
Add simple provenance schema

### DIFF
--- a/schemas/edges/wsprov_input_in.js
+++ b/schemas/edges/wsprov_input_in.js
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["_from", "_to"],
+  "description": "The workspace object was input in a provenance action",
+  "properties": {
+    "_from": {
+      "type": "string",
+      "examples": ["wsprov_object/1:2:3"]
+    },
+    "_to": {
+      "type": "string",
+      "examples": ["wsprov_action/1:2:3"]
+    }
+  }
+}
+
+

--- a/schemas/edges/wsprov_produced.json
+++ b/schemas/edges/wsprov_produced.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["_from", "_to"],
+  "description": "The provenance action produced the workspace object",
+  "properties": {
+    "_from": {
+      "type": "string",
+      "examples": ["wsprov_action/1:2:3"]
+    },
+    "_to": {
+      "type": "string",
+      "examples": ["wsprov_object/1:2:3"]
+    }
+  }
+}

--- a/schemas/edges/wsprov_similar_to.json
+++ b/schemas/edges/wsprov_similar_to.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["_from", "_to"],
+  "description": "The workspace object is similar to another object",
+  "properties": {
+    "_from": {
+      "type": "string",
+      "examples": ["wsprov_object/1:2:3"]
+    },
+    "_to": {
+      "type": "string",
+      "examples": ["wsprov_object/1:2:3"]
+    }
+  }
+}
+
+

--- a/schemas/vertices/wsprov_action.json
+++ b/schemas/vertices/wsprov_action.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "_key",
+    "workspace_id",
+    "runner"
+  ],
+  "properties": {
+    "_key": {
+      "type": "string",
+      "description": "Slugified name of the action with its timestamp and workspace id",
+      "examples": [ "copy:123123123:42" ]
+    },
+    "workspace_id": {
+      "type": "integer",
+      "description": "The workspace_id in which this action was performed",
+      "minimum": 1
+    },
+    "runner": {
+      "type": "string",
+      "description": "The person who ran this action"
+    }
+  }
+}
+

--- a/schemas/vertices/wsprov_object.json
+++ b/schemas/vertices/wsprov_object.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "_key",
+    "workspace_id",
+    "owner"
+  ],
+  "properties": {
+    "_key": {
+      "type": "string",
+      "description": "The workspace reference for this object",
+      "examples": [ "1:2:3" ]
+    },
+    "workspace_id": {
+      "type": "integer",
+      "description": "The workspace_id for this object",
+      "minimum": 1
+    },
+    "owner": {
+      "type": "string",
+      "description": "The owner of this workspace object"
+    }
+  }
+}


### PR DESCRIPTION
This is for building some kind of landing page UI for the GSP. No design is finalized so I'm not sure if this will end up being useful. But wanted to move forward with something..

Additional properties are allowed on these, I'd like it to be flexible

I'm building off the app code you sent me to iterate over objects by user and workspace

The only thing I'm not sure about is the `action.runner` user. I was just using the workspace owner, maybe there is something more accurate