### PR TITLE
Add ws provenance views

### DIFF
--- a/views/count_documents_in_collection.aql
+++ b/views/count_documents_in_collection.aql
@@ -1,8 +1,0 @@
-// Return count of documents in a collection
-// Args:
-//   collection - name of collection to count docs
-
-for v in @@collection
-  collect with count into length
-  return length
-

--- a/views/list_all_documents_in_collection.aql
+++ b/views/list_all_documents_in_collection.aql
@@ -1,6 +1,0 @@
-// Return *all* full documents in a collection
-// Args:
-//   collection - name of collection to count docs
-
-for v in @@collection
-  return v

--- a/views/wsprov_fetch_copies.aql
+++ b/views/wsprov_fetch_copies.aql
@@ -1,0 +1,24 @@
+// For a given object, fetch all the objects that it has been copied from or
+// to, no matter how many nested times (copies of copies of copies, forward or backward)
+// Also returns all linked objects of those copies of any nested level.
+// Each sublink result has a 'parent_id' point to the copy that it is linked from.
+// Args:
+//   obj_key - key of the object (eg "1:2:3")
+//   copy_limit - limit the amount of copy results
+//   sublink_limit - limit the amount of sublink object results
+
+let obj_id = CONCAT("wsprov_object/", @obj_key)
+let copies = (
+  for obj in 1..100 any obj_id wsprov_copied_into
+    filter obj
+    return obj
+)
+let sublinks = (
+  for obj in wsprov_object
+  filter obj in copies
+  for obj1 in 1..100 any obj wsprov_links
+    filter obj1
+    limit @sublink_limit
+    return distinct {parent_id: obj._id, obj: obj1}
+)
+return {copies: copies, sublinks: sublinks}

--- a/views/wsprov_fetch_linked_objects.aql
+++ b/views/wsprov_fetch_linked_objects.aql
@@ -1,0 +1,24 @@
+// Find all linked objects to a given object
+// Returns links of level 1, plus all child links of any nested level ("sublinks")
+// Each sublink has a "parent_id" key that points to its parent object
+// Args:
+//  key - wsprov_object key to find links for
+//  link_limit - how many 1st-level links to return
+//  sublink_limit - how many child links to return for each link
+
+let obj_id = CONCAT("wsprov_object/", @key)
+let links = (
+  for obj in 1..1 any obj_id wsprov_links
+    filter obj
+    limit @link_limit
+    return obj
+)
+let sublinks = (
+  for obj in wsprov_object
+    filter obj in links
+    for obj1 in 1..100 any obj wsprov_links
+      filter obj1
+      limit @sublink_limit
+      return distinct {parent_id: obj._id, obj: obj1}
+)
+return {links: links, sublinks: sublinks}

--- a/views/wsprov_fetch_multiple_linked_objects.aql
+++ b/views/wsprov_fetch_multiple_linked_objects.aql
@@ -1,0 +1,19 @@
+// For a set of wsprov_objects, fetch 1st-level linked objects for
+// each. This is used, for example, in fetching all linked objects for homology
+// results. This does not fetch sub-links (past 1st level nesting).
+// The returned objects will each have an 'obj' key (the actual document), as
+// well as a 'parent_id' key, which is the ID of the object to which it is
+// linked.
+// Args:
+//   obj_ids - array of object ids to fetch linked objects for
+//   link_limit - limit number of links to return for each parent object
+
+let links = (
+  for obj in wsprov_object
+    filter obj._id in @obj_ids
+    for obj1 in 1..100 any obj wsprov_links
+      filter obj1
+      limit @link_limit
+      return distinct {obj: obj1, parent_id: obj._id}
+)
+return {links: links}

--- a/views/wsprov_fetch_object.aql
+++ b/views/wsprov_fetch_object.aql
@@ -1,0 +1,7 @@
+// Fetch a wsprov_object
+// Args:
+//   key - key of the object to fetch
+
+for o in wsprov_object
+  filter o._key == @key
+  return o


### PR DESCRIPTION
This adds views that I'm using in the workspace provenance UI.

A few things I'm noticing in this spec workflow:
- would be nice to have defaults in view params (eg. @sublink_limit defaults to 10 if not set)
- would be nice to have tests for these somehow

These queries do not yet include any access control. That can be added by adding a param for workspace ids that the user can access, and doing a filter on all object queries using this param. Should be easy. I will index the workspace ID property of the objects collection beforehand.