### PR TITLE
add ws_ids in a let statement so they are accepted as params

### DIFF
--- a/views/list_genes_for_similar_reactions.aql
+++ b/views/list_genes_for_similar_reactions.aql
@@ -5,7 +5,7 @@
 //   df_sim - minimum difference fingerprint similarity score
 //   exclude_self - if true, don't include the query reactions genes
 
-let @ws_ids = ws_ids
+let ws_ids = @ws_ids
 
 let similar_rxn_ids = (
 for e in rxn_similar_to_reaction

--- a/views/list_genes_for_similar_reactions.aql
+++ b/views/list_genes_for_similar_reactions.aql
@@ -5,6 +5,8 @@
 //   df_sim - minimum difference fingerprint similarity score
 //   exclude_self - if true, don't include the query reactions genes
 
+let @ws_ids = ws_ids
+
 let similar_rxn_ids = (
 for e in rxn_similar_to_reaction
    filter e.sf_similarity >= @sf_sim


### PR DESCRIPTION
The logic of the access control in the API is such that it always passes at least an empty list for the `ws_ids` bind var. That means we'll have to add this no-op let statement to every query that does not require workspace auth