### PR TITLE
Tweak some logic in wsprov views

### DIFF
--- a/views/wsprov_fetch_copies.aql
+++ b/views/wsprov_fetch_copies.aql
@@ -7,11 +7,10 @@
 //   obj_key - key of the object (eg "1:2:3")
 //   copy_limit - max results of copies (recommended 10-20)
 
-for o in wsprov_object
-  filter o._key == @obj_key
-  filter o.is_public || (o.workspace_id IN @ws_ids)
-  for copy in 1..100 any o wsprov_copied_into
-    filter copy // no nulls
-    limit @copy_limit
-    collect parent_id = o._id into groups = copy
-    return distinct { copies: groups, parent_id }
+with wsprov_object
+let obj_id = CONCAT('wsprov_object/', @obj_key)
+for copy in 1..10 any obj_id wsprov_copied_into
+  filter copy.is_public || (copy.workspace_id IN @ws_ids)
+  limit @copy_limit
+  collect parent_id = obj_id into copies = copy
+  return distinct { copies, parent_id }

--- a/views/wsprov_fetch_linked_objects.aql
+++ b/views/wsprov_fetch_linked_objects.aql
@@ -1,4 +1,4 @@
-// Find all linked objects to a given object
+// Find all linked objects to a given set of objects
 // Returns links of level 1, plus all child links of any nested level ("sublinks")
 // Each sublink has a "parent_id" key that points to its parent object
 // Args:
@@ -8,10 +8,9 @@
 //   sublink_limit - number of sublink results (10-20 recommended)
 
 for o in wsprov_object
-  filter o._key IN @obj_keys
-  filter o.is_public || (o.workspace_id IN @ws_ids)
-  for link in 1..100 any o wsprov_links
+  filter o._key in @obj_keys
+  for link in 1..10 any o wsprov_links
+    filter link.is_public || link.workspace_id IN @ws_ids
     limit @link_limit
-    filter link // no nulls
-    collect parent_id = o._id into groups = link
-    return distinct { links: groups, parent_id }
+    collect parent_id = o._id into links = link
+    return { links, parent_id }

--- a/views/wsprov_fetch_linked_objects.aql
+++ b/views/wsprov_fetch_linked_objects.aql
@@ -5,7 +5,6 @@
 //   ws_ids - array of private workspace ids the user has access to
 //   obj_keys - wsprov_object key to find links for
 //   link_limit - number of link results (10-20 recommended)
-//   sublink_limit - number of sublink results (10-20 recommended)
 
 for o in wsprov_object
   filter o._key in @obj_keys


### PR DESCRIPTION
This checks workspace ID access on the sublinked objects and tweaks some of the query for performance using arango's explain feature

So below is the "correct" (I think) access control logic for the complicated workspace system for the gsp UI query:
- downstream references have read permissions regardless of the workspace
- upstream references have read permissions if the user has access to the workspace
- downstream provenance has read perms if the user has access to the workspace
- upstream provenance has read perms regardless of the workspace
- upstream or downstream copies have read perms if the user has access to the workspace

I found that overly complicated to implement in a query though. So instead we have kind of a subset of the above behavior in the query -- we always check for workspace access on every traversal. I think that's good enough for the short term.