### PR TITLE
Expand the wsprov linked object views a little to include both directions

### DIFF
--- a/views/wsprov_count_linked_object_types.aql
+++ b/views/wsprov_count_linked_object_types.aql
@@ -7,12 +7,32 @@
 //      *** if both show_private and show_public are true, this will be treated as an OR ***
 
 WITH wsprov_object
-LET obj_id = CONCAT("wsprov_object/", @obj_key)
-FOR v, e, p in 1..100
-  INBOUND obj_id wsprov_links, wsprov_copied_into
-  OPTIONS {uniqueVertices: "global", bfs: true}
-  FILTER (@show_private && @show_public) ? (v.is_public || v.workspace_id IN @ws_ids) :
-      (!@show_private || v.workspace_id IN @ws_ids) && (!@show_public || v.is_public)
-  COLLECT type = v.ws_type with count into type_count
-  SORT type_count DESC
-  RETURN {type, type_count}
+LET obj_id = concat('wsprov_object/', @obj_key)
+
+let out = FIRST(
+    for v, e, p in 1..100
+        OUTBOUND obj_id wsprov_links, wsprov_copied_into
+        OPTIONS {bfs: true, uniqueVertices: 'global'}
+        FILTER (!@type || v.ws_type == @type)
+        FILTER (!@owners || v.owner IN @owners)
+        FILTER (@show_private && @show_public)
+          ? (v.is_public || v.workspace_id IN @ws_ids)
+          : (!@show_private || v.workspace_id IN @ws_ids) && (!@show_public || v.is_public)
+        COLLECT type = v.ws_type with count into type_count
+        RETURN {type, type_count}
+)
+
+let inb = FIRST(
+    for v, e, p in 1..100
+        INBOUND obj_id wsprov_links, wsprov_copied_into
+        OPTIONS {bfs: true, uniqueVertices: 'global'}
+        FILTER (!@type || v.ws_type == @type)
+        FILTER (!@owners || v.owner IN @owners)
+        FILTER (@show_private && @show_public)
+          ? (v.is_public || v.workspace_id IN @ws_ids)
+          : (!@show_private || v.workspace_id IN @ws_ids) && (!@show_public || v.is_public)
+        COLLECT type = v.ws_type with count into type_count
+        RETURN {type, type_count}
+)
+
+return {out, inb}

--- a/views/wsprov_count_linked_object_types.aql
+++ b/views/wsprov_count_linked_object_types.aql
@@ -5,6 +5,8 @@
 //   show_private - limit to objects in workspaces that a user has access to
 //   show_public - limit to objects in public workspaces
 //      *** if both show_private and show_public are true, this will be treated as an OR ***
+//   type - ws type to filter on
+//   owners - list of usernames to filter by owner
 
 WITH wsprov_object
 LET obj_id = concat('wsprov_object/', @obj_key)

--- a/views/wsprov_fetch_linked_objects.aql
+++ b/views/wsprov_fetch_linked_objects.aql
@@ -12,25 +12,55 @@
 
 WITH wsprov_object
 LET obj_id = CONCAT("wsprov_object/", @obj_key)
-FOR v, e, p IN 1..100
-    INBOUND obj_id wsprov_links, wsprov_copied_into
-    OPTIONS {uniqueVertices: "global", bfs: true}
-    FILTER (!@type || v.ws_type == @type)
-    FILTER (!@owners || v.owner IN @owners)
-    FILTER (@show_private && @show_public)
-      ? (v.is_public || v.workspace_id IN @ws_ids)
-      : (!@show_private || v.workspace_id IN @ws_ids) && (!@show_public || v.is_public)
-    LIMIT @offset, @results_limit
-    RETURN {
-        vertex: {
-            _key: v._key,
-            is_public: v.is_public,
-            narr_name: v.narr_name,
-            obj_name: v.obj_name,
-            owner: v.owner,
-            save_date: v.save_date,
-            workspace_id: v.workspace_id,
-            ws_type: v.ws_type
-        },
-        type_path: p.vertices[*].ws_type
-    }
+
+let out = (
+    FOR v, e, p IN 1..100
+        OUTBOUND obj_id wsprov_links, wsprov_copied_into
+        OPTIONS {uniqueVertices: "global", bfs: true}
+        FILTER (!@type || v.ws_type == @type)
+        FILTER (!@owners || v.owner IN @owners)
+        FILTER (@show_private && @show_public)
+          ? (v.is_public || v.workspace_id IN @ws_ids)
+          : (!@show_private || v.workspace_id IN @ws_ids) && (!@show_public || v.is_public)
+        LIMIT @offset, @results_limit
+        RETURN {
+            vertex: {
+                _key: v._key,
+                is_public: v.is_public,
+                narr_name: v.narr_name,
+                obj_name: v.obj_name,
+                owner: v.owner,
+                save_date: v.save_date,
+                workspace_id: v.workspace_id,
+                ws_type: v.ws_type
+            },
+            path: p
+        }
+)
+
+let inb = (
+    FOR v, e, p IN 1..100
+        OUTBOUND obj_id wsprov_links, wsprov_copied_into
+        OPTIONS {uniqueVertices: "global", bfs: true}
+        FILTER (!@type || v.ws_type == @type)
+        FILTER (!@owners || v.owner IN @owners)
+        FILTER (@show_private && @show_public)
+          ? (v.is_public || v.workspace_id IN @ws_ids)
+          : (!@show_private || v.workspace_id IN @ws_ids) && (!@show_public || v.is_public)
+        LIMIT @offset, @results_limit
+        RETURN {
+            vertex: {
+                _key: v._key,
+                is_public: v.is_public,
+                narr_name: v.narr_name,
+                obj_name: v.obj_name,
+                owner: v.owner,
+                save_date: v.save_date,
+                workspace_id: v.workspace_id,
+                ws_type: v.ws_type
+            },
+            path: p
+        }
+)
+
+return APPEND(out, inb)


### PR DESCRIPTION
would like to expand the queries for the landing page UI a little:
- going unidirectionally inbound OR outbound on provenance, references, and copies
- type count query should have the same kind of traversal as the actual object query