### PR TITLE
Fetch references query for an object

### DIFF
--- a/views/wsprov_fetch_references.aql
+++ b/views/wsprov_fetch_references.aql
@@ -1,0 +1,17 @@
+// Fetch inbound references for an object with acl
+// Args:
+//   obj_key - wsprov_object ._key field that you want to query against
+//   result_limit - limit of object results
+//   offset - result offset for pagination
+//   ws_ids - array of private workspace ids the user has access to
+
+with wsprov_object
+
+let obj_id = concat('wsprov_object/', @obj_key)
+
+for v, e, p in 1..100 inbound obj_id wsprov_links
+    options {bfs: true, uniqueVertices: 'global'}   
+    filter p.edges[*].type all == 'reference'
+    filter v.is_public || v.workspace_id IN @ws_ids
+    limit @offset, @result_limit
+    return v


### PR DESCRIPTION
Lil query to fetch inbound references for an object

I'm going to use this in the homology results so that they can click through to a genome from an assembly.