### PR TITLE
View testing system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ python:
 before_script:
 - pip install jsonschema
 script:
+- docker-compose up --build -d
+- sleep 15
 - make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 from python:3.7-slim
 
-RUN pip install --upgrade pip requests
+RUN pip install --upgrade pip requests jsonschema
 
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+from python:3.7-slim
+
+RUN pip install --upgrade pip requests
+
+COPY . /app

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@
 
 test:
 	python test/validate.py
-
-test-server:
-	echo "TODO run a single-node arango database server with pre-loaded test data"
+	echo "Running view tests"
+	docker-compose run spec python /app/test/views/init_spec.py
+	docker-compose run spec python -m unittest discover /app/test/views

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,50 @@
+version: '3'
+
+# This docker-compose is for developer convenience and testing, not for running in production.
+
+services:
+
+  # ArangoDB
+  arangodb:
+    image: arangodb:3.4
+    ports:
+      - 8529:8529
+    environment:
+      - ARANGO_ROOT_PASSWORD=password
+
+  # Relation Engine API
+  re_api:
+    image: kbase/relation_engine_api:latest
+    ports:
+      - 5000:5000
+    environment:
+      - ARANGO_ROOT_PASSWORD=password
+    environment:
+      - DEVELOPMENT=1
+      - FLASK_ENV=development
+      - FLASK_DEBUG=1
+      - KBASE_AUTH_URL=http://auth:5000
+      - KBASE_WORKSPACE_URL=http://workspace:5000
+      - PYTHONUNBUFFERED=true
+      - SPEC_RELEASE_PATH=/app/src/test/spec_release/spec.tar.gz
+      - DB_URL=http://arangodb:8529
+      - DB_USER=root
+      - DB_PASS=password
+
+  # A mock kbase auth server (see src/test/mock_auth/endpoints.json)
+  auth:
+    image: mockservices/mock_json_service
+    volumes:
+      - ${PWD}/test/mock_services/mock_auth:/config
+
+  # Mock workspace server (see src/test/mock_workspace/endpoints.json)
+  workspace:
+    image: mockservices/mock_json_service
+    volumes:
+      - ${PWD}/test/mock_services/mock_workspace:/config
+
+  # General python container for executing tests
+  spec:
+    build: .
+    volumes:
+      - ${PWD}:/app

--- a/test/mock_services/mock_auth/endpoints.json
+++ b/test/mock_services/mock_auth/endpoints.json
@@ -1,0 +1,96 @@
+[
+  {
+    "methods": [
+      "GET"
+    ],
+    "path": "/api/V2/me",
+    "headers": {
+      "Authorization": "non_admin_token"
+    },
+    "response": {
+      "status": "200",
+      "body": {
+        "created": 1528306100471,
+        "lastlogin": 1542068355002,
+        "display": "Test User",
+        "roles": [],
+        "customroles": [],
+        "policyids": [],
+        "user": "username",
+        "local": false,
+        "email": "user@example.com",
+        "idents": []
+      }
+    }
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "path": "/api/V2/me",
+    "headers": {
+      "Authorization": "admin_token"
+    },
+    "response": {
+      "status": "200",
+      "body": {
+        "created": 1528306100471,
+        "lastlogin": 1542068355002,
+        "display": "Test User",
+        "roles": [],
+        "customroles": [
+          "RE_ADMIN"
+        ],
+        "policyids": [],
+        "user": "username",
+        "local": false,
+        "email": "user@example.com",
+        "idents": []
+      }
+    }
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "path": "/api/V2/me",
+    "headers": {
+      "Authorization": "invalid_token"
+    },
+    "response": {
+      "status": "401",
+      "body": {
+        "error": {
+          "httpcode": 401,
+          "httpstatus": "Unauthorized",
+          "appcode": 10020,
+          "apperror": "Invalid token",
+          "message": "10020 Invalid token",
+          "callid": "1757210147564211",
+          "time": 1542737889450
+        }
+      }
+    }
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "path": "/api/V2/me",
+    "response": {
+      "status": "400",
+      "body": {
+        "error": {
+          "httpcode": 400,
+          "httpstatus": "Bad Request",
+          "appcode": 10010,
+          "apperror": "No authentication token",
+          "message": "10010 No authentication token: No user token provided",
+          "callid": "7334881776774415",
+          "time": 1542737656377
+        }
+      }
+    }
+  }
+]
+

--- a/test/mock_services/mock_workspace/endpoints.json
+++ b/test/mock_services/mock_workspace/endpoints.json
@@ -1,0 +1,64 @@
+[
+  {
+    "methods": ["POST"],
+    "path": "/",
+    "headers": {"Authorization": "valid_token"},
+    "body": {
+      "method": "Workspace.list_workspace_ids",
+      "version": "1.1",
+      "params": [{"perm": "r"}]
+    },
+    "response": {
+      "status": "200",
+      "body": {
+        "version": "1.1",
+        "result": [
+          {
+            "workspaces": [1, 2, 3],
+            "pub": []
+          }
+        ]
+      }
+    }
+  },
+  {
+    "methods": ["POST"],
+    "path": "/",
+    "headers": {"Authorization": "invalid_token"},
+    "body": {
+      "method": "Workspace.list_workspace_ids",
+      "version": "1.1",
+      "params": [{"perm": "r"}]
+    },
+    "response": {
+      "status": "500",
+      "body": {
+        "version": "1.1",
+        "error": {
+          "name": "JSONRPCError",
+          "code": -32400,
+          "message": "Token validation failed!",
+          "error": "..."
+        }
+      }
+    }
+  },
+  {
+    "methods": ["POST"],
+    "path": "/",
+    "headers": {"Authorization": "admin_token"},
+    "body": {
+      "method": "Workspace.list_workspace_ids",
+      "version": "1.1",
+      "params": [{"perm": "r"}]
+    },
+    "response": {
+      "status": "200",
+      "body": {
+        "version": "1.1",
+        "result": [{"workspaces": [99], "pub": []}]
+      }
+    }
+  }
+]
+

--- a/test/views/init_spec.py
+++ b/test/views/init_spec.py
@@ -1,0 +1,12 @@
+import requests
+
+_API_URL = 'http://re_api:5000/api'
+
+
+if __name__ == '__main__':
+    resp = requests.get(
+        _API_URL + '/update_specs',
+        headers={'Authorization': 'admin_token'},
+        params={'init_collections': '1'}
+    )
+    print(resp)

--- a/test/views/test_list_test_vertices.py
+++ b/test/views/test_list_test_vertices.py
@@ -1,0 +1,46 @@
+import json
+import unittest
+import requests
+
+_API_URL = 'http://re_api:5000/api'
+_QUERY_URL = _API_URL + '/query_results?view=list_test_vertices'
+
+
+def create_test_docs(docs):
+    body = '\n'.join([json.dumps(d) for d in docs])
+    return requests.put(
+        _API_URL + '/documents',
+        params={'overwrite': True, 'collection': 'test_vertex'},
+        data=body,
+        headers={'Authorization': 'admin_token'}
+    ).json()
+
+
+class TestListTestVertices(unittest.TestCase):
+
+    def test_valid(self):
+        """Test a valid query."""
+        create_test_docs([
+            {'is_public': True, '_key': 'a', 'ws_id': 10},  # public access
+            {'is_public': False, '_key': 'b', 'ws_id': 1},  # private access
+            {'is_public': False, '_key': 'c', 'ws_id': 99}  # no access
+        ])
+        resp = requests.post(
+            _QUERY_URL,
+            headers={'Authorization': 'valid_token'}  # gives access to workspaces [1,2,3]
+        ).json()
+        self.assertEqual(resp['count'], 2)
+        # 'c' is inaccessible
+        self.assertEqual([r['_key'] for r in resp['results']], ['a', 'b'])
+
+    def test_no_auth(self):
+        """Test with blank auth."""
+        create_test_docs([
+            {'is_public': True, '_key': 'a', 'ws_id': 10},  # public access
+            {'is_public': False, '_key': 'b', 'ws_id': 1},  # private access
+            {'is_public': False, '_key': 'c', 'ws_id': 99}  # no access
+        ])
+        resp = requests.post(_QUERY_URL).json()
+        self.assertEqual(resp['count'], 1)
+        # 'b' and 'c' are inaccessible
+        self.assertEqual([r['_key'] for r in resp['results']], ['a'])


### PR DESCRIPTION
This allows spec writers to write tests for views, and to play with a live arango and RE API instance locally. Tests should run fine on travis as well.