### PR TITLE
Add a generalized OBO namespace

### DIFF
--- a/schemas/obo/obo_consider_replacement.yaml
+++ b/schemas/obo/obo_consider_replacement.yaml
@@ -1,0 +1,20 @@
+name: obo_consider_replacement
+type: edge
+schema:
+  "$schema": http://json-schema.org/draft-07/schema#
+  title: obo_consider_replacement
+  type: object
+  required: [id, from, to]
+  properties:
+    id:
+      type: string
+      description: Has the format 'from_term_id::to_term_id'
+      examples: ["GO:0000005::GO:0042254", "GO:0000005::GO:0044183"]
+    from:
+      type: string
+      description: Term ID
+      examples: ["GO:0023052"]
+    to:
+      type: string
+      title: Term ID
+      examples: ["GO:0008150"]

--- a/schemas/obo/obo_has_relationship.yaml
+++ b/schemas/obo/obo_has_relationship.yaml
@@ -1,0 +1,24 @@
+name: obo_has_relationship
+type: edge
+schema:
+  "$schema": http://json-schema.org/draft-07/schema#
+  description: The `from` obo term has a relationship to the `to` obo term
+  type: object
+  required: [id, from, to, relationship_type]
+  properties:
+    id:
+      type: string
+      description: Has the format of 'from_term_id::to_term_id::relationship_name'
+      examples: ["GO:0000136::GO:0031501::part_of", "GO:0000132::GO:0000278::has_part"]
+    from:
+      type: string
+      description: GO id
+      examples: ["GO:0023052"]
+    to:
+      type: string
+      title: GO id
+      examples: ["GO:0008150"]
+    type:
+      type: string
+      title: Relationship type
+      examples: [occurs_in, has_part, part_of]

--- a/schemas/obo/obo_is_replaced_by.yaml
+++ b/schemas/obo/obo_is_replaced_by.yaml
@@ -1,0 +1,20 @@
+name: obo_is_replaced_by
+type: edge
+schema:
+  "$schema": http://json-schema.org/draft-07/schema#
+  type: object
+  description: A `from` term was obsoleted and replaced by the `to` term
+  required: [id, from, to]
+  properties:
+    id:
+      type: string
+      description: Has the format "from_term_id::to_term_id"
+      examples: ["GO:0000108::GO:0000109", "GO:0000174::GO:0000750"]
+    from:
+      type: string
+      title: Term ID
+      examples: ["GO:0023052"]
+    to:
+      type: string
+      title: Term ID
+      examples: ["GO:0008150"]

--- a/schemas/obo/obo_term.yaml
+++ b/schemas/obo/obo_term.yaml
@@ -56,9 +56,9 @@ schema:
           xrefs:
             type: array
             items: {type: string}
-    xref:
+    xrefs:
       type: array
-      description: A database cross-reference that describes an analagous term in another vocabulary
+      description: Database cross-references that describe analagous terms in another vocabulary
       examples: [["Wikipedia:Reproduction"], ["KEGG_REACTION:R05612", "RHEA:20836"], ["GO:0042254", "GO:0008104", "GO:0051019"]]
       items: {type: string}
     is_obsolete:

--- a/schemas/obo/obo_term.yaml
+++ b/schemas/obo/obo_term.yaml
@@ -1,0 +1,76 @@
+name: obo_term
+type: vertex
+schema:
+  "$schema": http://json-schema.org/draft-07/schema#
+  title: Open Biological and Biomedical Ontology terms
+  type: object
+  required: [id, name]
+  properties:
+    id:
+      type: string
+      description: Unique ID of the term
+      examples: ["GO:0022609", "GO:0044848"]
+    name:
+      type: string
+      title: Term name
+      examples: ["mitochondrial genome maintenance", "reproduction"]
+    namespace:
+      type: string
+      description: Denotes a sub-ontology that the term belongs to.
+      examples: ["cellular component", "biological process", "molecular function"]
+    alt_id:
+      type: array
+      description: Defines an alternative ID for this term. A term may have any number of alternative ids.
+      examples: [["GO:0019952", "GO:0050876"], ["GO:0044848"]]
+    def:
+      type: string
+      title: Definition
+      examples:
+      - "'The directed movement of a ribosomal subunit from the nucleus into the cytoplasm.' [GOC:ai]"
+      - "'Catalysis of the reaction: adenine + H2O = hypoxanthine + NH3.' [EC:3.5.4.2]"
+    comment:
+      type: string
+      examples:
+      - This term was made obsolete because it refers to a class of gene products and
+        a biological process rather than a molecular function.
+    subset:
+      type: array
+      description: This tag indicates a term subset to which this term belongs.
+      examples:
+        - [goslim_yeast]
+        - [goslim_chembl, goslim_metagenomics, goslim_pir, goslim_plant]
+    synonym:
+      type: array
+      description: This tag gives a synonym for this term, some xrefs to describe the
+        origins of the synonym, and may indicate a synonym category or scope information.
+      examples:
+        - [{"pred": "hasExactSynonym", "val": "cellular component", "xrefs": []}]
+        - [{"pred": "hasRelatedSynonym", "val": "subcellular entity", "xrefs": ["NIF_Subcellular:nlx_subcell_100315"]}]
+      items:
+        type: object
+        required: [pred, val, xrefs]
+        additionalProperties: false
+        properties:
+          pred: {type: string}
+          val: {type: string}
+          xrefs:
+            type: array
+            items: {type: string}
+    xref:
+      type: array
+      description: A database cross-reference that describes an analagous term in another vocabulary
+      examples: [["Wikipedia:Reproduction"], ["KEGG_REACTION:R05612", "RHEA:20836"], ["GO:0042254", "GO:0008104", "GO:0051019"]]
+      items: {type: string}
+    is_obsolete:
+      type: boolean
+      description: Whether or not this term is obsolete.
+      examples: [true]
+      default: false
+    created_by:
+      type: string
+      description: Optional tag added by OBO-Edit to indicate the creator of the term
+      examples: [usernamexyz]
+    creation_date:
+      type: string
+      description: Optional tag added by OBO-Edit to indicate the creation time and date of the term
+      examples: ['2009-04-28T10:33:25Z']

--- a/schemas/obo/obo_term.yaml
+++ b/schemas/obo/obo_term.yaml
@@ -23,11 +23,18 @@ schema:
       description: Defines an alternative ID for this term. A term may have any number of alternative ids.
       examples: [["GO:0019952", "GO:0050876"], ["GO:0044848"]]
     def:
-      type: string
+      type: object
       title: Definition
       examples:
-      - "'The directed movement of a ribosomal subunit from the nucleus into the cytoplasm.' [GOC:ai]"
-      - "'Catalysis of the reaction: adenine + H2O = hypoxanthine + NH3.' [EC:3.5.4.2]"
+        - {"val": "The directed movement of a ribosomal subunit from the nucleus into the cytoplasm.", "xrefs": ["GOC:ai"]}
+        - {"val": "Catalysis of the reaction: adenine + H2O = hypoxanthine + NH3.", "xrefs": ["EC:3.5.4.2"]}
+      required: [val, xrefs]
+      additionalProperties: false
+      properties:
+        val: {type: string}
+        xrefs:
+          type: array
+          items: {type: string}
     comment:
       type: string
       examples:
@@ -35,14 +42,15 @@ schema:
         a biological process rather than a molecular function.
     subset:
       type: array
+      items: {type: string}
       description: This tag indicates a term subset to which this term belongs.
       examples:
         - [goslim_yeast]
         - [goslim_chembl, goslim_metagenomics, goslim_pir, goslim_plant]
     synonym:
       type: array
-      description: This tag gives a synonym for this term, some xrefs to describe the
-        origins of the synonym, and may indicate a synonym category or scope information.
+      description: Synonyms for this term with category or scope information. Also has database cross-references to describe the
+        origins of the synonym.
       examples:
         - [{"pred": "hasExactSynonym", "val": "cellular component", "xrefs": []}]
         - [{"pred": "hasRelatedSynonym", "val": "subcellular entity", "xrefs": ["NIF_Subcellular:nlx_subcell_100315"]}]

--- a/schemas/obo/obo_term.yaml
+++ b/schemas/obo/obo_term.yaml
@@ -20,6 +20,7 @@ schema:
       examples: ["cellular component", "biological process", "molecular function"]
     alt_id:
       type: array
+      items: {type: string}
       description: Defines an alternative ID for this term. A term may have any number of alternative ids.
       examples: [["GO:0019952", "GO:0050876"], ["GO:0044848"]]
     def:
@@ -80,5 +81,6 @@ schema:
       examples: [usernamexyz]
     creation_date:
       type: string
+      format: date-time
       description: Optional tag added by OBO-Edit to indicate the creation time and date of the term
       examples: ['2009-04-28T10:33:25Z']


### PR DESCRIPTION
Adds a namespace for generalized OBO-based ontologies

Related issue https://github.com/kbase/relation_engine_spec/issues/85

* Expands out the types for "synonyms" and "def" under the term
* Consolidates the "isa" and "relationship" edges
* Cleans up the edge IDs 
* Generally expands and cleans up some of the field types