### PR TITLE
Optimize and fix details of ncbi queries

### DIFF
--- a/stored_queries/ncbi_tax/ncbi_taxon_get_children.yaml
+++ b/stored_queries/ncbi_tax/ncbi_taxon_get_children.yaml
@@ -32,26 +32,25 @@ params:
       default: null
 query: |
   // Fetch the child IDs using the edge attributes
-  let children = (
-      for parent in ncbi_taxon
-        filter parent.id == @id
-        filter parent.created <= @ts AND parent.expired >= @ts
-        limit 1
-        for tax in 1..1 inbound parent ncbi_child_of_taxon
-            return tax
+  let child_ids = (
+    for e in ncbi_child_of_taxon
+      filter e.to == @id
+      filter e.created <= @ts AND e.expired >= @ts
+      return e.from
   )
   // Sort and filter the children
   // Should only get evaluated if search_text is truthy
   let searched = (
-      for tax in FULLTEXT(ncbi_taxon, "scientific_name", @search_text)
-        filter tax in children
-        return tax
+    for tax in FULLTEXT(ncbi_taxon, "scientific_name", @search_text)
+      filter tax.id in child_ids
+      return tax.id
   )
-  let filtered = @search_text ? searched : children
+  let filtered = @search_text ? searched : child_ids
   let results = (
-    for tax in filtered
+    for tax in ncbi_taxon
+      filter tax.id in filtered
       sort tax.scientific_name asc
       limit @offset, @limit
-      return @select ? KEEP(tax, @select) : tax
+      return distinct (@select ? KEEP(tax, @select) : tax)
   )
   return {total_count: COUNT(filtered), results: results}

--- a/stored_queries/ncbi_tax/ncbi_taxon_get_children_cursor.yaml
+++ b/stored_queries/ncbi_tax/ncbi_taxon_get_children_cursor.yaml
@@ -22,4 +22,4 @@ query: |
     filter tax.created <= @ts AND tax.expired >= @ts
     limit 1
     for child in 1..1 inbound tax ncbi_child_of_taxon
-    return @select ? KEEP(tax, @select) : tax
+      return @select ? KEEP(tax, @select) : tax

--- a/stored_queries/ncbi_tax/ncbi_taxon_get_lineage.yaml
+++ b/stored_queries/ncbi_tax/ncbi_taxon_get_lineage.yaml
@@ -25,7 +25,7 @@ query: |
       limit 1
       for ancestor, e, path in 1..10 outbound t ncbi_child_of_taxon
         options {bfs: true}
-        filter path.edges[*].created ALL <= @ts AND path.edges[*].expired >= @ts
+        filter path.edges[*].created ALL <= @ts AND path.edges[*].expired ALL >= @ts
         return distinct (@select ? KEEP(ancestor, @select) : ancestor)
   )
   // doing return reverse(ps) returns an array of an array for some reason,

--- a/stored_queries/ncbi_tax/ncbi_taxon_get_lineage.yaml
+++ b/stored_queries/ncbi_tax/ncbi_taxon_get_lineage.yaml
@@ -23,10 +23,10 @@ query: |
       filter t.id == @id
       filter t.created <= @ts AND t.expired >= @ts
       limit 1
-      for p, e in 1..10 outbound t ncbi_child_of_taxon
+      for ancestor, e, path in 1..10 outbound t ncbi_child_of_taxon
         options {bfs: true}
-        filter p.created <= @ts AND p.expired >= @ts
-        return distinct (@select ? KEEP(p, @select) : p)
+        filter path.edges[*].created ALL <= @ts AND path.edges[*].expired >= @ts
+        return distinct (@select ? KEEP(ancestor, @select) : ancestor)
   )
   // doing return reverse(ps) returns an array of an array for some reason,
   // which we don't want

--- a/stored_queries/ncbi_tax/ncbi_taxon_get_siblings.yaml
+++ b/stored_queries/ncbi_tax/ncbi_taxon_get_siblings.yaml
@@ -29,22 +29,26 @@ params:
       default: null
 query: |
   // Fetch the siblings
-  let siblings = ( for t in ncbi_taxon
-      filter t.id == @id
-      filter t.created <= @ts AND t.expired >= @ts
+  let parent_id = first(
+    for e in ncbi_child_of_taxon
+      filter e.from == @id
+      filter e.created <= @ts and e.expired >= @ts
       limit 1
-      for parent in 1..1 outbound t ncbi_child_of_taxon
-        filter parent.created <= @ts AND parent.expired >= @ts
-        for child in 1..1 inbound parent ncbi_child_of_taxon
-          filter child != t
-          filter child.created <= @ts AND child.expired >= @ts
-          sort child.scientific_name asc
-          return child
+      return e.to
   )
-  // Apply limits to the results
-  let limited = (
-    for tax in siblings
+  let sibling_ids = (
+    for e in ncbi_child_of_taxon
+      filter e.to == parent_id
+      filter e.created <= @ts and e.expired >= @ts
+      filter e.from != @id
+      return e.from
+  )
+  // Apply sort and limits to the results
+  let siblings = (
+    for tax in ncbi_taxon
+      filter tax.id in sibling_ids
+      sort tax.scientific_name asc
       limit @offset, @limit
-      return @select ? KEEP(tax, @select) : tax
+      return distinct (@select ? KEEP(tax, @select) : tax)
   )
-  return {total_count: COUNT(siblings), results: limited}
+  return {total_count: COUNT(sibling_ids), results: siblings}

--- a/test/stored_queries/test_ncbi_tax.py
+++ b/test/stored_queries/test_ncbi_tax.py
@@ -33,8 +33,9 @@ def _create_delta_test_docs(coll_name, docs, edge=False):
     """Add in delta required fields."""
     if edge:
         for doc in docs:
-            doc['from'] = doc['_from']
-            doc['to'] = doc['_to']
+            # Replicate the time-travel system by just setting 'from' and 'to' to the keys
+            doc['from'] = doc['_from'].split('/')[1]
+            doc['to'] = doc['_to'].split('/')[1]
     else:
         for doc in docs:
             doc['id'] = doc['_key']


### PR DESCRIPTION
* Optimize get_children and get_siblings by getting away from the traversal syntax (arangodb issue here: https://github.com/arangodb/arangodb/issues/10053
* Fix the filter on the lineage traversal up descendants to use the whole path.
* Return distinct on both siblings and children.
* Fix fake test data to replicate delta docs a little more closely