### PR TITLE
Add object type information for ncbi taxon->object query

### DIFF
--- a/schemas/ws/ws_type.yaml
+++ b/schemas/ws/ws_type.yaml
@@ -10,3 +10,9 @@ schema:
       type: string
       examples: [KBaseGenomes.Genome]
       pattern: "^\\w+\\.\\w+$"
+    module_name:
+      type: string
+      examples: ['KBaseGenomes']
+    type_name:
+      type: string
+      examples: ['Genome']

--- a/schemas/ws/ws_type_version.yaml
+++ b/schemas/ws/ws_type_version.yaml
@@ -8,5 +8,17 @@ schema:
   properties:
     _key:
       type: string
-      examples: [KBaseGenomes.Genome‑9.0]
+      examples: ['KBaseGenomes.Genome‑9.0']
       pattern: "^\\w+\\.\\w+-\\d+\\.\\d+$"
+    module_name:
+      type: string
+      examples: ['KBaseGenomes']
+    type_name:
+      type: string
+      examples: ['Genome']
+    maj_ver:
+      type: integer
+      min: 0
+    min_ver:
+      type: integer
+      min: 0

--- a/stored_queries/ncbi_tax/ncbi_taxon_get_associated_ws_objects.yaml
+++ b/stored_queries/ncbi_tax/ncbi_taxon_get_associated_ws_objects.yaml
@@ -49,9 +49,9 @@ query: |
       filter tax.created <= @ts AND tax.expired >= @ts
       limit 1
       for obj, e in 1 inbound tax ws_obj_version_has_taxon
+        filter obj.is_public or obj.workspace_id IN ws_ids
+        limit @offset, @limit
         for type in 1 outbound obj ws_obj_instance_of_type
-          filter obj.is_public or obj.workspace_id IN ws_ids
-          limit @offset, @limit
           let t = KEEP(type, ['_key', 'module_name', 'type_name', 'maj_ver', 'min_ver'])
           let o = MERGE(obj, {type: t})
           return {

--- a/stored_queries/ncbi_tax/ncbi_taxon_get_associated_ws_objects.yaml
+++ b/stored_queries/ncbi_tax/ncbi_taxon_get_associated_ws_objects.yaml
@@ -52,9 +52,10 @@ query: |
         for type in 1 outbound obj ws_obj_instance_of_type
           filter obj.is_public or obj.workspace_id IN ws_ids
           limit @offset, @limit
-          let o = MERGE(obj, {type: type})
+          let t = KEEP(type, ['_key', 'module_name', 'type_name', 'maj_ver', 'min_ver'])
+          let o = MERGE(obj, {type: t})
           return {
-            ws_obj: @select_obj ? KEEP(obj, @select_obj) : obj,
+            ws_obj: @select_obj ? KEEP(o, @select_obj) : o,
             edge: @select_edge ? KEEP(e, @select_edge) : e
           }
   )

--- a/stored_queries/ncbi_tax/ncbi_taxon_get_associated_ws_objects.yaml
+++ b/stored_queries/ncbi_tax/ncbi_taxon_get_associated_ws_objects.yaml
@@ -33,7 +33,7 @@ params:
       items: {type: string}
       description: Taxon edge fields to keep in the results
       default: null
-query_prefix: WITH ws_object_version
+query_prefix: WITH ws_object_version, ws_type_version
 query: |
   let count = COUNT(
     for tax in ncbi_taxon
@@ -48,12 +48,14 @@ query: |
       filter tax.id == @taxon_id
       filter tax.created <= @ts AND tax.expired >= @ts
       limit 1
-      for obj, e in 1..1 inbound tax ws_obj_version_has_taxon
-        filter obj.is_public or obj.workspace_id IN ws_ids
-        limit @offset, @limit
-        return {
-          ws_obj: @select_obj ? KEEP(obj, @select_obj) : obj,
-          edge: @select_edge ? KEEP(e, @select_edge) : e
-        }
+      for obj, e in 1 inbound tax ws_obj_version_has_taxon
+        for type in 1 outbound obj ws_obj_instance_of_type
+          filter obj.is_public or obj.workspace_id IN ws_ids
+          limit @offset, @limit
+          let o = MERGE(obj, {type: type})
+          return {
+            ws_obj: @select_obj ? KEEP(obj, @select_obj) : obj,
+            edge: @select_edge ? KEEP(e, @select_edge) : e
+          }
   )
   return {results, total_count: count}

--- a/test/stored_queries/test_ncbi_tax.py
+++ b/test/stored_queries/test_ncbi_tax.py
@@ -285,7 +285,8 @@ class TestNcbiTax(unittest.TestCase):
         resp = requests.post(
             _CONF['re_api_url'] + '/api/v1/query_results',
             params={'stored_query': 'ncbi_taxon_get_associated_ws_objects'},
-            data=json.dumps({'ts': _NOW, 'taxon_id': '1', 'select_obj': ['_id'], 'select_edge': ['assigned_by']}),
+            data=json.dumps({'ts': _NOW, 'taxon_id': '1', 'select_obj': ['_id', 'type'],
+                             'select_edge': ['assigned_by']}),
         ).json()
         self.assertEqual(resp['count'], 1)
         results = resp['results'][0]
@@ -295,3 +296,4 @@ class TestNcbiTax(unittest.TestCase):
         ids = {ret['ws_obj']['_id'] for ret in results['results']}
         self.assertEqual(assignments, {'assn1', 'assn2'})
         self.assertEqual(ids, {'ws_object_version/1:1:1', 'ws_object_version/1:1:2'})
+        self.assertEqual(results['results'][0]['ws_obj']['type']['type_name'], 'Genome')

--- a/test/stored_queries/test_ncbi_tax.py
+++ b/test/stored_queries/test_ncbi_tax.py
@@ -85,12 +85,12 @@ class TestNcbiTax(unittest.TestCase):
             {'_from': 'ws_workspace/2', '_to': 'ws_object_version/2:1:1'},
         ]
         ws_type_version_docs = [
-            {'_key': 'KBaseGenomes.Genome-99.99', 'module_name': 'KBaseGenomes',
-             'type_name': 'Genome', 'maj_ver': 99, 'min_ver': 99}
+            {'_key': 'KBaseGenomes.Genome-99.77', 'module_name': 'KBaseGenomes',
+             'type_name': 'Genome', 'maj_ver': 99, 'min_ver': 77}
         ]
         ws_obj_instance_of_type_docs = [
-            {'_from': 'ws_object_version/1:1:1', '_to': 'ws_type_version/KBaseGenomes.Genome-99.99'},
-            {'_from': 'ws_object_version/1:1:2', '_to': 'ws_type_version/KBaseGenomes.Genome-99.99'}
+            {'_from': 'ws_object_version/1:1:1', '_to': 'ws_type_version/KBaseGenomes.Genome-99.77'},
+            {'_from': 'ws_object_version/1:1:2', '_to': 'ws_type_version/KBaseGenomes.Genome-99.77'}
         ]
         _create_delta_test_docs('ncbi_taxon', taxon_docs)
         _create_delta_test_docs('ncbi_child_of_taxon', child_docs, edge=True)
@@ -296,4 +296,10 @@ class TestNcbiTax(unittest.TestCase):
         ids = {ret['ws_obj']['_id'] for ret in results['results']}
         self.assertEqual(assignments, {'assn1', 'assn2'})
         self.assertEqual(ids, {'ws_object_version/1:1:1', 'ws_object_version/1:1:2'})
-        self.assertEqual(results['results'][0]['ws_obj']['type']['type_name'], 'Genome')
+        self.assertEqual(results['results'][0]['ws_obj']['type'], {
+            'type_name': 'Genome',
+            'module_name': 'KBaseGenomes',
+            'maj_ver': 99,
+            'min_ver': 77,
+            '_key': 'KBaseGenomes.Genome-99.77'
+        })

--- a/test/stored_queries/test_ncbi_tax.py
+++ b/test/stored_queries/test_ncbi_tax.py
@@ -84,12 +84,22 @@ class TestNcbiTax(unittest.TestCase):
             {'_from': 'ws_workspace/1', '_to': 'ws_object_version/1:1:2'},
             {'_from': 'ws_workspace/2', '_to': 'ws_object_version/2:1:1'},
         ]
+        ws_type_version_docs = [
+            {'_key': 'KBaseGenomes.Genome-99.99', 'module_name': 'KBaseGenomes',
+             'type_name': 'Genome', 'maj_ver': 99, 'min_ver': 99}
+        ]
+        ws_obj_instance_of_type_docs = [
+            {'_from': 'ws_object_version/1:1:1', '_to': 'ws_type_version/KBaseGenomes.Genome-99.99'},
+            {'_from': 'ws_object_version/1:1:2', '_to': 'ws_type_version/KBaseGenomes.Genome-99.99'}
+        ]
         _create_delta_test_docs('ncbi_taxon', taxon_docs)
         _create_delta_test_docs('ncbi_child_of_taxon', child_docs, edge=True)
         _create_delta_test_docs('ws_object_version', obj_docs)
         _create_delta_test_docs('ws_obj_version_has_taxon', obj_to_taxa_docs, edge=True)
         _create_delta_test_docs('ws_workspace', ws_docs)
         _create_delta_test_docs('ws_workspace_contains_obj', ws_to_obj, edge=True)
+        create_test_docs('ws_obj_instance_of_type', ws_obj_instance_of_type_docs)
+        create_test_docs('ws_type_version', ws_type_version_docs)
 
     def test_get_lineage_valid(self):
         """Test a valid query of taxon lineage."""


### PR DESCRIPTION
* Add a few useful fields for type vertices in the `ws` namespace
* Return the object type in the ncbi_tax_get_associated_ws_objects query