### PR TITLE
Update feature key regex

### DIFF
--- a/schemas/ws/ws_genome_features.yaml
+++ b/schemas/ws/ws_genome_features.yaml
@@ -14,6 +14,7 @@ schema:
       type: string
       description: The UPA and feature ID for this data
       examples: ["35414:73:1_RSP_4039"]
+      # see https://www.arangodb.com/docs/stable/data-modeling-naming-conventions-document-keys.html
       pattern: "^\\d+:\\d+:\\d+_[a-zA-Z0-9_\\-:\\.@\\(\\)\\+,=;\\$!\\*'%]*$"
     feature_id:
       type: string

--- a/schemas/ws/ws_genome_features.yaml
+++ b/schemas/ws/ws_genome_features.yaml
@@ -14,7 +14,7 @@ schema:
       type: string
       description: The UPA and feature ID for this data
       examples: ["35414:73:1_RSP_4039"]
-      pattern: "^\\d+:\\d+:\\d+_[a-zA-Z0-9_\-:\.@\(\)\+,=;\$!\*'%]*$"
+      pattern: "^\\d+:\\d+:\\d+_[a-zA-Z0-9_\\-:\\.@\\(\\)\\+,=;\\$!\\*'%]*$"
     feature_id:
       type: string
       description: The unique ID of the feature within the genome

--- a/schemas/ws/ws_genome_features.yaml
+++ b/schemas/ws/ws_genome_features.yaml
@@ -14,12 +14,11 @@ schema:
       type: string
       description: The UPA and feature ID for this data
       examples: ["35414:73:1_RSP_4039"]
-      pattern: "^\\d+:\\d+:\\d+_\\w*$"  # may need to expand the feature ID part
+      pattern: "^\\d+:\\d+:\\d+_[a-zA-Z0-9_\-:\.@\(\)\+,=;\$!\*'%]*$"
     feature_id:
       type: string
       description: The unique ID of the feature within the genome
       examples: ["RSP_4039"]
-      pattern: "^\\w*$" # may need to expand
     workspace_id:
       type: integer
       description: The workspace ID for the genome containing this feature

--- a/schemas/ws/ws_genome_has_feature.yaml
+++ b/schemas/ws/ws_genome_has_feature.yaml
@@ -10,7 +10,7 @@ schema:
       type: string
       examples: ['75:82:3_RSP_4039']
       description: The unique, permanent ID of this edge. Identical to the feature _key entry.
-      pattern: "^\\d+:\\d+:\\d+_\\w*$"  # may need to expand the feature ID part
+      pattern: "^\\d+:\\d+:\\d+_[a-zA-Z0-9_\-:\.@\(\)\+,=;\$!\*'%]*$"
     _from:
       type: string
       examples: ['ws_object_version/75:82:3']

--- a/schemas/ws/ws_genome_has_feature.yaml
+++ b/schemas/ws/ws_genome_has_feature.yaml
@@ -10,6 +10,7 @@ schema:
       type: string
       examples: ['75:82:3_RSP_4039']
       description: The unique, permanent ID of this edge. Identical to the feature _key entry.
+      # see https://www.arangodb.com/docs/stable/data-modeling-naming-conventions-document-keys.html
       pattern: "^\\d+:\\d+:\\d+_[a-zA-Z0-9_\\-:\\.@\\(\\)\\+,=;\\$!\\*'%]*$"
     _from:
       type: string

--- a/schemas/ws/ws_genome_has_feature.yaml
+++ b/schemas/ws/ws_genome_has_feature.yaml
@@ -10,7 +10,7 @@ schema:
       type: string
       examples: ['75:82:3_RSP_4039']
       description: The unique, permanent ID of this edge. Identical to the feature _key entry.
-      pattern: "^\\d+:\\d+:\\d+_[a-zA-Z0-9_\-:\.@\(\)\+,=;\$!\*'%]*$"
+      pattern: "^\\d+:\\d+:\\d+_[a-zA-Z0-9_\\-:\\.@\\(\\)\\+,=;\\$!\\*'%]*$"
     _from:
       type: string
       examples: ['ws_object_version/75:82:3']


### PR DESCRIPTION
Some features have non-word characters. Update the feature key regex to allow
any ADB allowed characters.

Also remove the regex for the feature ID so the original feature ID can
be included.