### PR TITLE
Return workspace info for ncbi_taxon_get_associated_ws_objects

### DIFF
--- a/schemas/ws/ws_workspace.yaml
+++ b/schemas/ws/ws_workspace.yaml
@@ -10,9 +10,6 @@ schema:
       description: The workspace ID for this workspace
       examples: ['35414']
       pattern: "^\\d+$"
-    narr_name:
-      type: string
-      title: Narrative name
     owner:
       type: string
       title: Username of workspace owner

--- a/stored_queries/ncbi_tax/ncbi_taxon_get_associated_ws_objects.yaml
+++ b/stored_queries/ncbi_tax/ncbi_taxon_get_associated_ws_objects.yaml
@@ -58,7 +58,8 @@ query: |
         LET unver_id = CONCAT("ws_object/", TO_STRING(obj.workspace_id), ':', TO_STRING(obj.object_id))
         LET ws_info = FIRST(
           FOR ws IN 1 INBOUND unver_id ws_workspace_contains_obj
-            RETURN KEEP(ws, ['owner', 'metadata', 'is_public', 'is_deleted', 'mod_epoch'])
+            FILTER !ws.is_deleted
+            RETURN KEEP(ws, ['owner', 'metadata', 'is_public', 'mod_epoch'])
         )
         LET o = MERGE(obj, {type, ws_info})
         RETURN {

--- a/stored_queries/ncbi_tax/ncbi_taxon_get_associated_ws_objects.yaml
+++ b/stored_queries/ncbi_tax/ncbi_taxon_get_associated_ws_objects.yaml
@@ -33,7 +33,7 @@ params:
       items: {type: string}
       description: Taxon edge fields to keep in the results
       default: null
-query_prefix: WITH ws_object_version, ws_type_version
+query_prefix: WITH ws_object_version, ws_type_version, ws_workspace
 query: |
   let count = COUNT(
     for tax in ncbi_taxon
@@ -51,12 +51,19 @@ query: |
       for obj, e in 1 inbound tax ws_obj_version_has_taxon
         filter obj.is_public or obj.workspace_id IN ws_ids
         limit @offset, @limit
-        for type in 1 outbound obj ws_obj_instance_of_type
-          let t = KEEP(type, ['_key', 'module_name', 'type_name', 'maj_ver', 'min_ver'])
-          let o = MERGE(obj, {type: t})
-          return {
-            ws_obj: @select_obj ? KEEP(o, @select_obj) : o,
-            edge: @select_edge ? KEEP(e, @select_edge) : e
-          }
+        let type = first(
+          for type in 1 outbound obj ws_obj_instance_of_type
+            return KEEP(type, ['_key', 'module_name', 'type_name', 'maj_ver', 'min_ver'])
+        )
+        let unver_id = CONCAT("ws_object/", TO_STRING(obj.workspace_id), ':', TO_STRING(obj.object_id))
+        let ws_info = first(
+          for ws in 1 inbound unver_id ws_workspace_contains_obj
+            return KEEP(ws, ['owner', 'metadata', 'is_public', 'is_deleted', 'mod_epoch'])
+        )
+        let o = MERGE(obj, {type, ws_info})
+        return {
+          ws_obj: @select_obj ? KEEP(o, @select_obj) : o,
+          edge: @select_edge ? KEEP(e, @select_edge) : e
+        }
   )
   return {results, total_count: count}

--- a/stored_queries/ncbi_tax/ncbi_taxon_get_associated_ws_objects.yaml
+++ b/stored_queries/ncbi_tax/ncbi_taxon_get_associated_ws_objects.yaml
@@ -35,35 +35,35 @@ params:
       default: null
 query_prefix: WITH ws_object_version, ws_type_version, ws_workspace
 query: |
-  let count = COUNT(
-    for tax in ncbi_taxon
-      filter tax.id == @taxon_id
-      filter tax.created <= @ts AND tax.expired >= @ts
-      limit 1
-      for obj in 1..1 inbound tax ws_obj_version_has_taxon
-        return 1
+  LET count = COUNT(
+    FOR tax IN ncbi_taxon
+      FILTER tax.id == @taxon_id
+      FILTER tax.created <= @ts AND tax.expired >= @ts
+      LIMIT 1
+      FOR obj IN 1..1 INBOUND tax ws_obj_version_has_taxon
+        RETURN 1
   )
-  let results = (
-    for tax in ncbi_taxon
-      filter tax.id == @taxon_id
-      filter tax.created <= @ts AND tax.expired >= @ts
-      limit 1
-      for obj, e in 1 inbound tax ws_obj_version_has_taxon
-        filter obj.is_public or obj.workspace_id IN ws_ids
-        limit @offset, @limit
-        let type = first(
-          for type in 1 outbound obj ws_obj_instance_of_type
-            return KEEP(type, ['_key', 'module_name', 'type_name', 'maj_ver', 'min_ver'])
+  LET results = (
+    FOR tax IN ncbi_taxon
+      FILTER tax.id == @taxon_id
+      FILTER tax.created <= @ts AND tax.expired >= @ts
+      LIMIT 1
+      FOR obj, e IN 1 INBOUND tax ws_obj_version_has_taxon
+        FILTER obj.is_public OR obj.workspace_id IN ws_ids
+        LIMIT @offset, @limit
+        LET type = first(
+          FOR type IN 1 OUTBOUND obj ws_obj_instance_of_type
+            RETURN KEEP(type, ['_key', 'module_name', 'type_name', 'maj_ver', 'min_ver'])
         )
-        let unver_id = CONCAT("ws_object/", TO_STRING(obj.workspace_id), ':', TO_STRING(obj.object_id))
-        let ws_info = first(
-          for ws in 1 inbound unver_id ws_workspace_contains_obj
-            return KEEP(ws, ['owner', 'metadata', 'is_public', 'is_deleted', 'mod_epoch'])
+        LET unver_id = CONCAT("ws_object/", TO_STRING(obj.workspace_id), ':', TO_STRING(obj.object_id))
+        LET ws_info = FIRST(
+          FOR ws IN 1 INBOUND unver_id ws_workspace_contains_obj
+            RETURN KEEP(ws, ['owner', 'metadata', 'is_public', 'is_deleted', 'mod_epoch'])
         )
-        let o = MERGE(obj, {type, ws_info})
-        return {
+        LET o = MERGE(obj, {type, ws_info})
+        RETURN {
           ws_obj: @select_obj ? KEEP(o, @select_obj) : o,
           edge: @select_edge ? KEEP(e, @select_edge) : e
         }
   )
-  return {results, total_count: count}
+  RETURN {results, total_count: count}

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -54,6 +54,12 @@ def wait_for_api():
             time.sleep(2)
 
 
+def assert_subset(testCls, subset, _dict):
+    """Replacement for the deprecated `assertDictContainsSubset` method."""
+    for (key, val) in subset.items():
+        testCls.assertEqual(subset.get(key), _dict.get(key))
+
+
 if __name__ == '__main__':
     if sys.argv[1] == 'wait_for_api':
         wait_for_api()

--- a/test/stored_queries/helpers.py
+++ b/test/stored_queries/helpers.py
@@ -10,7 +10,7 @@ def create_test_docs(coll_name, docs):
     body = '\n'.join([json.dumps(d) for d in docs])
     resp = requests.put(
         _CONF['re_api_url'] + '/api/v1/documents',
-        params={'overwrite': True, 'collection': coll_name},
+        params={'overwrite': True, 'collection': coll_name, 'display_errors': '1'},
         data=body,
         headers={'Authorization': 'admin_token'}
     )

--- a/test/stored_queries/test_ncbi_tax.py
+++ b/test/stored_queries/test_ncbi_tax.py
@@ -341,7 +341,6 @@ class TestNcbiTax(unittest.TestCase):
             'owner': 'owner',
             'metadata': {'narrative_nice_name': 'narrname'},
             'is_public': True,
-            'is_deleted': False,
             'mod_epoch': 1
         })
 

--- a/test/stored_queries/test_ncbi_tax.py
+++ b/test/stored_queries/test_ncbi_tax.py
@@ -6,7 +6,7 @@ import time
 import unittest
 import requests
 
-from test.helpers import get_config
+from test.helpers import get_config, assert_subset
 from test.stored_queries.helpers import create_test_docs
 
 _CONF = get_config()
@@ -23,13 +23,13 @@ def _ws_defaults(data):
         'mod_epoch': 1,
         'is_public': True,
         'is_deleted': False,
-        'metadata': {},
+        'metadata': {'narrative_nice_name': 'narrname'},
     }
     # Merge the data with the above defaults
     return dict(defaults, **data)
 
 
-def _construct_ws_obj(wsid, objid, ver, is_public=False):
+def _construct_ws_obj_ver(wsid, objid, ver, is_public=False):
     """Test helper to create a ws_object_version vertex."""
     return {
         '_key': f"{wsid}:{objid}:{ver}",
@@ -40,6 +40,17 @@ def _construct_ws_obj(wsid, objid, ver, is_public=False):
         'hash': 'xyz',
         'size': 100,
         'epoch': 0,
+        'deleted': False,
+        'is_public': is_public,
+    }
+
+
+def _construct_ws_obj(wsid, objid, is_public=False):
+    """Test helper to create a ws_object vertex."""
+    return {
+        '_key': f"{wsid}:{objid}",
+        'workspace_id': wsid,
+        'object_id': objid,
         'deleted': False,
         'is_public': is_public,
     }
@@ -83,10 +94,14 @@ class TestNcbiTax(unittest.TestCase):
             {'_from': 'ncbi_taxon/6', '_to': 'ncbi_taxon/4', 'child_type': 't'},
             {'_from': 'ncbi_taxon/7', '_to': 'ncbi_taxon/4', 'child_type': 't'},
         ]
+        obj_ver_docs = [
+            _construct_ws_obj_ver(1, 1, 1, is_public=True),
+            _construct_ws_obj_ver(1, 1, 2, is_public=True),
+            _construct_ws_obj_ver(2, 1, 1, is_public=False),
+        ]
         obj_docs = [
-            _construct_ws_obj(1, 1, 1, is_public=True),
-            _construct_ws_obj(1, 1, 2, is_public=True),
-            _construct_ws_obj(2, 1, 1, is_public=False),
+            _construct_ws_obj(1, 1, is_public=True),
+            _construct_ws_obj(2, 1, is_public=False),
         ]
         obj_to_taxa_docs = [
             {'_from': 'ws_object_version/1:1:1', '_to': 'ncbi_taxon/1', 'assigned_by': 'assn1'},
@@ -99,9 +114,8 @@ class TestNcbiTax(unittest.TestCase):
             _ws_defaults({'_key': '2', 'is_public': False}),
         ]
         ws_to_obj = [
-            {'_from': 'ws_workspace/1', '_to': 'ws_object_version/1:1:1'},
-            {'_from': 'ws_workspace/1', '_to': 'ws_object_version/1:1:2'},
-            {'_from': 'ws_workspace/2', '_to': 'ws_object_version/2:1:1'},
+            {'_from': 'ws_workspace/1', '_to': 'ws_object/1:1'},
+            {'_from': 'ws_workspace/2', '_to': 'ws_object/2:1'},
         ]
         ws_type_version_docs = [
             {'_key': 'KBaseGenomes.Genome-99.77', 'module_name': 'KBaseGenomes',
@@ -113,10 +127,11 @@ class TestNcbiTax(unittest.TestCase):
         ]
         _create_delta_test_docs('ncbi_taxon', taxon_docs)
         _create_delta_test_docs('ncbi_child_of_taxon', child_docs, edge=True)
-        _create_delta_test_docs('ws_object_version', obj_docs)
-        _create_delta_test_docs('ws_obj_version_has_taxon', obj_to_taxa_docs, edge=True)
-        _create_delta_test_docs('ws_workspace', ws_docs)
-        _create_delta_test_docs('ws_workspace_contains_obj', ws_to_obj, edge=True)
+        create_test_docs('ws_obj_version_has_taxon', obj_to_taxa_docs)
+        create_test_docs('ws_object', obj_docs)
+        create_test_docs('ws_workspace', ws_docs)
+        create_test_docs('ws_workspace_contains_obj', ws_to_obj)
+        create_test_docs('ws_object_version', obj_ver_docs)
         create_test_docs('ws_obj_instance_of_type', ws_obj_instance_of_type_docs)
         create_test_docs('ws_type_version', ws_type_version_docs)
 
@@ -304,7 +319,7 @@ class TestNcbiTax(unittest.TestCase):
         resp = requests.post(
             _CONF['re_api_url'] + '/api/v1/query_results',
             params={'stored_query': 'ncbi_taxon_get_associated_ws_objects'},
-            data=json.dumps({'ts': _NOW, 'taxon_id': '1', 'select_obj': ['_id', 'type'],
+            data=json.dumps({'ts': _NOW, 'taxon_id': '1', 'select_obj': ['_id', 'type', 'ws_info'],
                              'select_edge': ['assigned_by']}),
         ).json()
         self.assertEqual(resp['count'], 1)
@@ -322,17 +337,24 @@ class TestNcbiTax(unittest.TestCase):
             'min_ver': 77,
             '_key': 'KBaseGenomes.Genome-99.77'
         })
+        self.assertEqual(results['results'][0]['ws_obj']['ws_info'], {
+            'owner': 'owner',
+            'metadata': {'narrative_nice_name': 'narrname'},
+            'is_public': True,
+            'is_deleted': False,
+            'mod_epoch': 1
+        })
 
-        def test_get_taxon_from_ws_obj(self):
-            """Fetch the taxon vertex from a workspace versioned id."""
-            resp = requests.post(
-                _CONF['re_api_url'] + '/api/v1/query_results',
-                params={'stored_query': 'ncbi_taxon_get_taxon_from_ws_obj'},
-                data=json.dumps({'ts': _NOW, 'obj_ref': '1:1:1'})
-            ).json()
-            self.assertEqual(resp['count'], 1)
-            self.assertDictContainsSubset({
-                'id': '1',
-                'scientific_name': 'Bacteria',
-                'rank': 'Domain'
-            }, resp['result'][0])
+    def test_get_taxon_from_ws_obj(self):
+        """Fetch the taxon vertex from a workspace versioned id."""
+        resp = requests.post(
+            _CONF['re_api_url'] + '/api/v1/query_results',
+            params={'stored_query': 'ncbi_taxon_get_taxon_from_ws_obj'},
+            data=json.dumps({'ts': _NOW, 'obj_ref': '1:1:1'})
+        ).json()
+        self.assertEqual(resp['count'], 1)
+        assert_subset(self, {
+            'id': '1',
+            'scientific_name': 'Bacteria',
+            'rank': 'Domain'
+        }, resp['results'][0])


### PR DESCRIPTION
* Return workspace info in ncbi query
* Remove narrative name from the ws_workspace specs. There's no reason to have it there now that we are saving the metadata. Breaking change.
* Remove the deprecated `assertDictContainsSubset` method and add a small helper to replace it.
* Expand tests and fix some stuff there. Happy-case test covers the ws_info getting returned in the query.
* Remove accidental extra indentation for the `test_get_taxon_from_ws_obj` method