### PR TITLE
Dont filter out expired taxon verts when fetching the taxon for a ws obj

### DIFF
--- a/stored_queries/taxonomy/taxonomy_get_associated_ws_objects.yaml
+++ b/stored_queries/taxonomy/taxonomy_get_associated_ws_objects.yaml
@@ -50,7 +50,7 @@ query: |
   LET results = (
     FOR tax IN @@taxon_coll
       FILTER tax.id == @taxon_id
-      FILTER tax.created <= @ts AND tax.expired >= @ts
+      FILTER tax.created <= @ts
       LIMIT 1
       FOR obj, e IN 1 INBOUND tax ws_obj_version_has_taxon
         FILTER obj.is_public OR obj.workspace_id IN ws_ids

--- a/stored_queries/taxonomy/taxonomy_get_taxon_from_ws_obj.yaml
+++ b/stored_queries/taxonomy/taxonomy_get_taxon_from_ws_obj.yaml
@@ -20,7 +20,7 @@ query: |
     filter obj._key == @obj_ref
     filter obj.is_public or obj.workspace_id IN ws_ids
     for tax in 1 outbound obj ws_obj_version_has_taxon
-      filter tax.created <= @ts AND tax.expired >= @ts
+      filter tax.created <= @ts
       limit 1
       return tax
 


### PR DESCRIPTION
If I update taxonomy, some taxon edges for previous wsobj-to-taxon assignments get expired, and then don't get returned by these queries. For example, I saw this happen for all pseudomonas assignments in the last update. The users will most likely still want to see those taxon assignments.

This is a simple and quick fix to not filter out any expired taxa